### PR TITLE
[TASK-106] Add system sound play methods

### DIFF
--- a/Assets/Prefabs/Camera/Main Camera.prefab
+++ b/Assets/Prefabs/Camera/Main Camera.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5792159634458106060}
   - component: {fileID: 5792159634458106061}
   - component: {fileID: 5792159634458106051}
+  - component: {fileID: -1723334414005357527}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -91,3 +92,11 @@ MonoBehaviour:
   cameraPivot: {fileID: 0}
   offset: {x: 0, y: 5, z: -8}
   followSpeed: 10
+--- !u!81 &-1723334414005357527
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5792159634458106063}
+  m_Enabled: 1

--- a/Assets/Prefabs/Managers/GameManager.prefab
+++ b/Assets/Prefabs/Managers/GameManager.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1952887676603024736}
   - component: {fileID: 456424696575196388}
+  - component: {fileID: 4394515203195265553}
+  - component: {fileID: 6685709969993217270}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -44,3 +46,197 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5aa46c8ee19f4431691b62b96ae41fae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playManager: {fileID: 0}
+  totalPlayTime: 0
+--- !u!82 &4394515203195265553
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5102369382100634283}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 1
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!82 &6685709969993217270
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5102369382100634283}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -8,6 +8,9 @@ public class GameManager : MonoBehaviour
     public PlayManager playManager;
     public float totalPlayTime = 0;
 
+    private AudioSource _bgmSource;
+    private AudioSource _sfxSource;
+
     private void Awake()
     {
         if (Instance != null)
@@ -18,6 +21,11 @@ public class GameManager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+
+        /* Set AudioSource */
+        var audioSources = GetComponents<AudioSource>();
+        _bgmSource = audioSources[0];
+        _sfxSource = audioSources[1];
     }
 
     private void Start()
@@ -40,5 +48,31 @@ public class GameManager : MonoBehaviour
     {
         sceneName ??= SceneManager.GetActiveScene().name;
         SceneManager.LoadScene(sceneName);
+    }
+
+    /// <summary>
+    /// Plays a background music.
+    /// </summary>
+    public void PlayBgm(AudioClip clip)
+    {
+        _bgmSource.Stop();
+        _bgmSource.clip = clip;
+        _bgmSource.Play();
+    }
+
+    /// <summary>
+    /// Stops playing the background music.
+    /// </summary>
+    public void StopBgm()
+    {
+        _bgmSource.Stop();
+    }
+
+    /// <summary>
+    /// Plays a sound effect.
+    /// </summary>
+    public void PlaySfx(AudioClip clip)
+    {
+        _sfxSource.PlayOneShot(clip);
     }
 }


### PR DESCRIPTION
## 작업 내용
- GameManager에 BGM 및 시스템 SFX 재생 함수를 추가하였습니다.
- Camera prefab에 AudioListener를 추가했습니다.

## 확인 내용
- 추가된 함수로 재생 시 Camera의 위치에 상관 없이 음량이 일정한지 확인해주시기 바랍니다.

## 기타 사항
- 이 함수들은 BGM 및 시스템 효과음 재생을 위한 함수입니다. 월드의 특정 지점에서 발생하는 소리(ex: 바람 소리, 문이 열리는 소리)는 이 함수를 사용하지 않고, 해당 위치의 오브젝트가 가지고 있는 AudioSource를 이용하시기 바랍니다.