### PR TITLE
[ETC] Modify camera pivot position

### DIFF
--- a/Assets/Prefabs/Commons/Main Camera.prefab
+++ b/Assets/Prefabs/Commons/Main Camera.prefab
@@ -90,7 +90,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cameraPivot: {fileID: 0}
-  offset: {x: 0, y: 2, z: -5}
+  pivotOffset: {x: 0, y: 2, z: 0}
+  cameraOffset: {x: 0, y: 2, z: -5}
   followSpeed: 10
 --- !u!81 &-1723334414005357527
 AudioListener:

--- a/Assets/Prefabs/Commons/Player.prefab
+++ b/Assets/Prefabs/Commons/Player.prefab
@@ -161,9 +161,9 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4035505422769387702}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 87.11524, y: 2.563873, z: -3.75}
-  m_LocalScale: {x: 1.1590999, y: 1.1590999, z: 1.1590999}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4035505422719600765}

--- a/Assets/Scripts/Commons/CameraFollow.cs
+++ b/Assets/Scripts/Commons/CameraFollow.cs
@@ -3,13 +3,14 @@ using UnityEngine;
 public class CameraFollow : MonoBehaviour
 {
     public Transform cameraPivot;
-    public Vector3 offset = new Vector3(0f,5f, -20f);
-    public float followSpeed = 10f;
+    public Vector3 pivotOffset;
+    public Vector3 cameraOffset;
+    public float followSpeed;
 
     private void LateUpdate()
     {
-        Vector3 targetPos = cameraPivot.position + cameraPivot.rotation * offset;
-        transform.position = Vector3.Lerp(transform.position, targetPos, followSpeed * Time.deltaTime);
-        transform.LookAt(cameraPivot);
+        var cameraTargetPos = cameraPivot.position + cameraPivot.rotation * cameraOffset;
+        transform.position = Vector3.Lerp(transform.position, cameraTargetPos, followSpeed * Time.deltaTime);
+        transform.LookAt(cameraPivot.position + pivotOffset);
     }
 }


### PR DESCRIPTION
## 작업 내용
- `CameraFollow.cs` 에서 피벗 오브젝트 위치와 실제 피벗 기준 위치를 분리했습니다.
- `Main Camera.prefab` 에서 카메라 피벗 위치를 (0, 2, 0)으로 조정하였습니다. 이 변경 사항에 따라 달라지는 카메라 표시 영역은 첨부된 사진을 참고해주시기 바랍니다.
<details>
<summary>수정 전/후 스크린샷</summary>

- 수정 전
![image](https://github.com/user-attachments/assets/6dda5f2a-7925-4fdb-85de-eb5bdae43717)

- 수정 후
![image](https://github.com/user-attachments/assets/6046aa70-a0dd-4076-85cc-d757d8320bb7)

</details>

## 확인 내용
- 변경 사항이 각 Scene에서 제대로 적용되는지
- 조정된 수치가 적절한지

## 기타 사항
- 피벗 오프셋 및 카메라 오프셋은 Main Camera Prefab 혹은 각 Scene의 오브젝트의 Inspector에서 조정 가능합니다.
![image](https://github.com/user-attachments/assets/11191d57-882b-4d6f-8045-d00376447436)
- 피벗 오프셋, 카메라 오프셋이 의미하는 것은 다음 사진을 참고하시기 바랍니다.
![image](https://github.com/user-attachments/assets/8a630f99-5102-4906-88cd-e8e52a4533e0)
