### PR TITLE
[ETC] Minor fixes

### DIFF
--- a/Assets/Models/pidgeonhole.fbx.meta
+++ b/Assets/Models/pidgeonhole.fbx.meta
@@ -1,0 +1,107 @@
+fileFormatVersion: 2
+guid: 310fec5a4f54e8246820e6e804a528ae
+ModelImporter:
+  serializedVersion: 21300
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 1
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Commons/Ground/BumpedCantMediumLeft.prefab
+++ b/Assets/Prefabs/Commons/Ground/BumpedCantMediumLeft.prefab
@@ -43,6 +43,7 @@ GameObject:
   - component: {fileID: 3908813051136294593}
   - component: {fileID: 2227535373486098315}
   - component: {fileID: 3444252883739124511}
+  - component: {fileID: 978869668214247581}
   m_Layer: 0
   m_Name: default
   m_TagString: Untagged
@@ -72,7 +73,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5226651380101262842}
-  m_Mesh: {fileID: -2432090755550338912, guid: 5cf2f528bc62a794fa97828764bd0962, type: 3}
+  m_Mesh: {fileID: -2432090755550338912, guid: 3ff8f6eb20c6e7044a98b88848a48da2, type: 3}
 --- !u!23 &3444252883739124511
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -93,7 +94,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: -3033667219593020291, guid: 5cf2f528bc62a794fa97828764bd0962, type: 3}
+  - {fileID: -3033667219593020291, guid: 3ff8f6eb20c6e7044a98b88848a48da2, type: 3}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -115,3 +116,17 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &978869668214247581
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226651380101262842}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -2432090755550338912, guid: 3ff8f6eb20c6e7044a98b88848a48da2, type: 3}


### PR DESCRIPTION
## 작업 내용
- `pidgeonhole.fbx.meta` 를 생성했습니다.
- `BumpedCantMediumLeft.prefab` 에 Mesh 및 Material 지정, Collider가 누락된 부분을 수정하였습니다.

## 확인 내용
- 수정 사항이 제대로 반영되었는지

## 기타 사항
- 해당 PR이 Merge된 후 Unity 작업 시 `main` 브랜치를 해당 작업 브랜치로 Merge 혹은 Rebase 할 것이 권장됩니다. 그렇지 않을 경우 추후 PR에서 `pidgeonhole.fbx.meta`에서 충돌이 발생할 수 있습니다.

## hierachy 및 inspector 캡처 (필요 시)
- `BumpedCantMediumLeft.prefab/default`
![image](https://github.com/user-attachments/assets/63080897-f912-4eb3-8a0a-404609076a07)
