### PR TITLE
[ETC] added space for consistency in UI formatting

### DIFF
--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -35,12 +35,12 @@ public class UIManager : MonoBehaviour
 
     public void UpdatePlayTime(float playTime)
     {
-        playTimeText.text = $"Playtime...{FormatPlayTime(playTime)}";
+        playTimeText.text = $"Playtime... {FormatPlayTime(playTime)}";
     }
 
     public void UpdateCurrentPlayTime(float playTime)
     {
-        currentPlayTimeText.text = $"On current stage...{FormatPlayTime(playTime)}";
+        currentPlayTimeText.text = $"On current stage... {FormatPlayTime(playTime)}";
     }
 
     public void UpdateStage(string stageName)


### PR DESCRIPTION
## 작업 내용
- 시작 전 play time은 time... 00:00.00으로 뜨고, 시작한 뒤에는 time...00:00.00과 같이 뜨는 문제 해결 (띄어쓰기 통일)

## 확인 내용
- 딱히 x, 기존 pr에서 하나의 커밋만 따로 pr하고 나머지는 닫은 거라 이미 확인해 주신 부분임

## 기타 사항
- x

## hierachy 및 inspector 캡처 (필요 시)
